### PR TITLE
fix: allow to generate goreleaser oss compatible configs

### DIFF
--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -20,3 +20,12 @@ type Include struct { // pro only
 
 // IncludedMarkdown type alias.
 type IncludedMarkdown Include
+
+// MarshalYAML implements yaml.Marshaler.
+func (i IncludedMarkdown) MarshalYAML() (interface{}, error) {
+	if i.Content != "" {
+		return i.Content, nil
+	}
+	type alias IncludedMarkdown
+	return alias(i), nil
+}


### PR DESCRIPTION
many fields that are strings in goreleaser oss are of type IncludedMarkdown in goreleaser pro.

IncludedMarkdown can be parsed from a string in pro as well, but we don't have the custom marshal logic here.

This allows the caller to set `IncludedMarkdown.Content`, and if so, generate it a string.

